### PR TITLE
Add symbol download support

### DIFF
--- a/backtesting_demo/README.md
+++ b/backtesting_demo/README.md
@@ -10,10 +10,34 @@ This folder contains a very small Python application that demonstrates how a sim
 - `run_backtest.py` – command line entry point.
 - `data/` – contains a small sample dataset (`AAPL.csv`).
 
+## Requirements
+
+Install the dependencies with:
+
+```bash
+pip install pandas requests yfinance
+```
+
 ## Running
+
+The `data` argument can be a local file path, a URL to a CSV file, or a ticker symbol.
 
 ```bash
 python -m backtesting_demo.run_backtest backtesting_demo/data/AAPL.csv
+```
+
+You can also provide a URL to a CSV file. The script will download it
+automatically if the local path doesn't exist:
+
+```bash
+python -m backtesting_demo.run_backtest "https://example.com/AAPL.csv"
+```
+
+Alternatively, pass a ticker symbol and the data will be fetched using
+`yfinance`:
+
+```bash
+python -m backtesting_demo.run_backtest AAPL
 ```
 
 You can override the moving average windows:

--- a/backtesting_demo/data_loader.py
+++ b/backtesting_demo/data_loader.py
@@ -1,12 +1,33 @@
-import pandas as pd
+import io
 from pathlib import Path
+from urllib.parse import urlparse
+
+import pandas as pd
+import requests
+import yfinance as yf
 
 
-def load_csv(path: str) -> pd.DataFrame:
-    """Load OHLCV data from a CSV file."""
-    file_path = Path(path)
-    if not file_path.exists():
-        raise FileNotFoundError(f"Could not find data file: {file_path}")
-    df = pd.read_csv(file_path, parse_dates=["Date"])
+def load_csv(source: str) -> pd.DataFrame:
+    """Load OHLCV data from a CSV file, URL, or ticker symbol."""
+    file_path = Path(source)
+
+    if file_path.exists():
+        df = pd.read_csv(file_path, parse_dates=["Date"])
+    else:
+        parsed = urlparse(source)
+        if parsed.scheme and parsed.netloc:
+            resp = requests.get(source)
+            resp.raise_for_status()
+            df = pd.read_csv(io.StringIO(resp.text), parse_dates=["Date"])
+        else:
+            data = yf.download(source, progress=False)
+            if data.empty:
+                raise FileNotFoundError(
+                    f"Could not find data file or download symbol: {source}"
+                )
+            data.index.name = "Date"
+            data.reset_index(inplace=True)
+            df = data
+
     df = df.sort_values("Date").reset_index(drop=True)
     return df

--- a/backtesting_demo/run_backtest.py
+++ b/backtesting_demo/run_backtest.py
@@ -1,5 +1,4 @@
 import argparse
-from pathlib import Path
 
 from backtesting_demo.data_loader import load_csv
 from backtesting_demo.strategy import MovingAverageCrossoverStrategy
@@ -8,7 +7,11 @@ from backtesting_demo.backtester import Backtester
 
 def main():
     parser = argparse.ArgumentParser(description="Simple backtesting demo")
-    parser.add_argument("data", type=str, help="Path to OHLCV CSV file")
+    parser.add_argument(
+        "data",
+        type=str,
+        help="Path/URL to OHLCV CSV file or ticker symbol",
+    )
     parser.add_argument("--fast", type=int, default=5, help="Fast moving average window")
     parser.add_argument("--slow", type=int, default=10, help="Slow moving average window")
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- enable data loader to fetch from Yahoo Finance when given a symbol
- update CLI help message
- document ticker option and dependencies

## Testing
- `python -m backtesting_demo.run_backtest backtesting_demo/data/AAPL.csv --fast 3 --slow 7` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68442c9ff6ac83319bdb232ad02570dc