### PR TITLE
Fix ModuleNotFoundError when running run_backtest.py directly

### DIFF
--- a/backtesting_demo/run_backtest.py
+++ b/backtesting_demo/run_backtest.py
@@ -1,4 +1,10 @@
 import argparse
+import sys
+from pathlib import Path
+
+if __package__ is None or __package__ == "":
+    # Allow running this script directly without installing the package
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from backtesting_demo.data_loader import load_csv
 from backtesting_demo.strategy import MovingAverageCrossoverStrategy


### PR DESCRIPTION
## Summary
- update `run_backtest.py` to adjust `sys.path` when run as a script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844824e514c833196821e7bec226d18